### PR TITLE
Fix division by zero in Aim Trainer accuracy

### DIFF
--- a/aim.trainer.py
+++ b/aim.trainer.py
@@ -114,7 +114,11 @@ def end_screen(win, elapsed_time, targets_pressed, clicks):
     speed = round(targets_pressed / elapsed_time, 1)
     speed_label = LABEL_FONT.render(f"Speed: {speed} t/s", 1, "white")
     hits_label = LABEL_FONT.render(f"Hits: {targets_pressed}", 1, "white")
-    accuracy = round(targets_pressed / clicks * 100, 1)
+    # Avoid a division by zero if the player never clicked
+    if clicks:
+        accuracy = round(targets_pressed / clicks * 100, 1)
+    else:
+        accuracy = 0
     accuracy_label = LABEL_FONT.render(f"Accuracy: {accuracy}%", 1, "white")
 
     # Center the labels on the screen

--- a/aim_trainer.py
+++ b/aim_trainer.py
@@ -114,7 +114,11 @@ def end_screen(win, elapsed_time, targets_pressed, clicks):
     speed = round(targets_pressed / elapsed_time, 1)
     speed_label = LABEL_FONT.render(f"Speed: {speed} t/s", 1, "white")
     hits_label = LABEL_FONT.render(f"Hits: {targets_pressed}", 1, "white")
-    accuracy = round(targets_pressed / clicks * 100, 1)
+    # Avoid a division by zero if the player never clicked
+    if clicks:
+        accuracy = round(targets_pressed / clicks * 100, 1)
+    else:
+        accuracy = 0
     accuracy_label = LABEL_FONT.render(f"Accuracy: {accuracy}%", 1, "white")
 
     # Center the labels on the screen


### PR DESCRIPTION
## Summary
- prevent a crash when calculating accuracy if no clicks occurred

## Testing
- `python -m py_compile aim_trainer.py aim.trainer.py`

------
https://chatgpt.com/codex/tasks/task_e_684b60b12b7c8325b061d57f8b803f24